### PR TITLE
Use re.replace options string as replace options, and use MatchEvaluator.nreplace to avoid nasty surprises

### DIFF
--- a/src/PCRE2Wrapper.cc
+++ b/src/PCRE2Wrapper.cc
@@ -290,10 +290,9 @@ void PCRE2Wrapper::Replace(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 			int en = 0;
 			jpcre2::SIZE_T eo = 0;
 			jpcre2::MOD::toReplaceOption(obj->flags, true, &po, &jo, &en, &eo);
-			std::string result = me.replace(true, po);
+			std::string result = me.nreplace(true, po);
 			info.GetReturnValue().Set(Nan::New(result).ToLocalChecked());
 		}
-		
 	}
 }
 

--- a/src/PCRE2Wrapper.cc
+++ b/src/PCRE2Wrapper.cc
@@ -284,10 +284,16 @@ void PCRE2Wrapper::Replace(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 				return *Nan::Utf8String(returned);
 			}
 		);
+
+		{
+			jpcre2::Uint po = 0, jo = 0;
+			int en = 0;
+			jpcre2::SIZE_T eo = 0;
+			jpcre2::MOD::toReplaceOption(obj->flags, true, &po, &jo, &en, &eo);
+			std::string result = me.replace(true, po);
+			info.GetReturnValue().Set(Nan::New(result).ToLocalChecked());
+		}
 		
-		std::string result = me.replace();
-		
-		info.GetReturnValue().Set(Nan::New(result).ToLocalChecked());
 	}
 }
 


### PR DESCRIPTION
Using the options string to set replace options means that for example the options ‘e’ and ‘E’ can be used to ignore
missing captures during replace.

Using `MatchEvaluator.nreplace` means that the replacement text is not re-matched by `pcre2_substitute`. In order to allow Node callbacks, we dress up a single operation as two operations: first we match the pattern and gather the replacements from the callback function, then we insert the replacements. The difference between `replace` and `nreplace` is what happens in this second phase: `replace` calls `pcre2_substitute` to do the replacement, so the subject is re-matched, whereas `nreplace` just inserts the replacement strings in the positions of the original matches. This latter method is simpler and less likely to surprise the caller.