### PR TITLE
Make unset captures null, not the empty string

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/jpcre2"]
 	path = deps/jpcre2
-	url = git://github.com/jpcre2/jpcre2.git
+	url = git://github.com/rrthomas/jpcre2.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,17 +20,13 @@
 			"libraries": [ "../build_pcre2/lib/libpcre2-8.a" ],
 			'conditions': [
 				[ 'OS!="win"', {
-					'cflags+': [ '-std=c++11' ],
-					'cflags_c+': [ '-std=c++11' ],
-					'cflags_cc+': [ '-std=c++11' ],
+					'cflags_cc+': [ '-std=c++17' ],
+				}],
+				[ 'OS=="win"', {
+					'cflags_cc+': [ '/std:c++17' ],
 				}],
 			],
-			'cflags!': [ '-O2' ],
-			'cflags+': [ '-O3' ],
-			'cflags_cc!': [ '-O2' ],
-			'cflags_cc+': [ '-O3' ],
-			'cflags_c!': [ '-O2' ],
-			'cflags_c+': [ '-O3' ],
+			'defines': [ 'JPCRE2_UNSET_CAPTURES_NULL' ],
 		},
 	]
 }


### PR DESCRIPTION
It is important to be able to differentiate an empty match from a non-match.

Unfortunately, JPCRE2 does not permit this as-is. I have submitted a PR to
fix it: https://github.com/jpcre2/jpcre2/pull/31

Since the JPCRE2 maintainer is happy to take some form of the patch, but has
not found time to deal with it, I have replaced the JPCRE2 repo with my fork
that contains the PR.

Finally, this commit slightly simplifies binding.gyp: it removes the -O3
settings, as binding-gyp uses this by default anyway now, and updates the
language version to C++17, as this is required for my patch to JPCRE2.