### PR TITLE
lib/pcre2.js remove commented code that’s identical to existing code

### DIFF
--- a/lib/pcre2.js
+++ b/lib/pcre2.js
@@ -19,12 +19,6 @@ if (Symbol) {
 	}
 	
 	/*
-	if (Symbol.match) {
-		lib.PCRE2.prototype[Symbol.match] = lib.PCRE2JIT.prototype[Symbol.match] = function(str) {
-			return this.match(str);
-		}
-	}
-	
 	if (Symbol.search) {
 		lib.PCRE2.prototype[Symbol.search] = lib.PCRE2JIT.prototype[Symbol.search] = function(str) {
 			return this.search(str);


### PR DESCRIPTION
The commented stanza for Symbol.match is identical to the current code for
Symbol.match, so remove it.