### PR TITLE
Switch back to jpcre2 upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/build_pcre2/
+/node_modules/
+/package-lock.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/jpcre2"]
 	path = deps/jpcre2
-	url = git://github.com/rrthomas/jpcre2.git
+	url = git://github.com/jpcre2/jpcre2.git

--- a/deps/pcre2/.gitignore
+++ b/deps/pcre2/.gitignore
@@ -2,6 +2,7 @@ Makefile
 config.status
 config.log
 libtool
+autom4te.cache/
 
 src/*.o
 src/*.lo
@@ -9,6 +10,7 @@ src/config.h
 src/pcre2.h
 src/.dirstamp
 src/stamp-h1
+src/pcre2_chartables.c
 src/.*/
 .libs/
 libpcre2-*.pc


### PR DESCRIPTION
jpcre2 upstream now has my patch for returning unmatched captures as nulls,
so switch back to it.

Also make some improvements to .gitignores.